### PR TITLE
Add testproject

### DIFF
--- a/arden.xtext.tests/.classpath
+++ b/arden.xtext.tests/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="src" path="src-gen"/>
+    <classpathentry kind="src" path="xtend-gen"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/arden.xtext.tests/.project
+++ b/arden.xtext.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>arden.xtext.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/arden.xtext.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/arden.xtext.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/arden.xtext.tests/META-INF/MANIFEST.MF
+++ b/arden.xtext.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,24 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: arden.xtext.tests
+Bundle-Vendor: My Company
+Bundle-Version: 1.0.0.qualifier
+Bundle-SymbolicName: arden.xtext.tests; singleton:=true
+Bundle-ActivationPolicy: lazy
+Require-Bundle: arden.xtext,
+ arden.xtext.ui,
+ org.eclipse.core.runtime,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.ui.workbench;resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+Import-Package: org.apache.log4j,
+ org.junit;version="4.5.0",
+ org.junit.runner;version="4.5.0",
+ org.junit.runner.manipulation;version="4.5.0",
+ org.junit.runner.notification;version="4.5.0",
+ org.junit.runners;version="4.5.0",
+ org.junit.runners.model;version="4.5.0",
+ org.hamcrest.core
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Export-Package: arden.xtext

--- a/arden.xtext.tests/build.properties
+++ b/arden.xtext.tests/build.properties
@@ -1,0 +1,5 @@
+source.. = src/,\
+          src-gen/,\
+          xtend-gen/
+bin.includes = META-INF/,\
+       .

--- a/arden.xtext.tests/src/arden/xtext/tests/ParserTest.xtend
+++ b/arden.xtext.tests/src/arden/xtext/tests/ParserTest.xtend
@@ -1,0 +1,108 @@
+package arden.xtext.tests
+
+import com.google.inject.Inject
+import arden.xtext.ArdenSyntaxInjectorProvider
+import org.eclipse.xtext.junit4.InjectWith
+import org.eclipse.xtext.junit4.XtextRunner
+import org.eclipse.xtext.junit4.util.ParseHelper
+import org.eclipse.xtext.junit4.validation.ValidationTestHelper
+import org.junit.Test
+import org.junit.runner.RunWith
+import arden.xtext.ardenSyntax.mlms
+
+@RunWith(XtextRunner)
+@InjectWith(ArdenSyntaxInjectorProvider)
+class ParserTest {
+	
+	@Inject extension ParseHelper<mlms>
+	@Inject extension ValidationTestHelper
+
+    @Test
+    def void testHelloWorld() {
+        '''
+            // You may run this MLM with: $ arden2bytecode -r hello_world.mlm
+            
+            maintenance:
+                title: Hello World Example;;
+                mlmname: hello_world;;
+                arden: version 2.1;;  
+                version: 1.0;;
+                institution: Peter L. Reichertz Institut;;
+                author: Hannes Flicka;;
+                specialist: Hannes Flicka;;
+                date: 2011-09-08;;
+                validation: testing;;
+            
+            library:
+                purpose: Demonstration of Arden Syntax and read statement;;
+                explanation: n.a.;;
+                keywords: hello world, example, arden2bytecode, read statement;;
+                links: http://arden2bytecode.sf.net/ ;;
+            
+            knowledge:
+                type: data-driven;;
+                data:
+                    name := read {Enter your name};
+                    stdout_dest := destination{STDOUT}; 
+                ;;
+            
+                evoke: ;; // MLM is called directly
+                  
+                logic:
+                    conclude true;;
+            
+                action:
+                    write "Hello " || name || "! " at stdout_dest; 
+                ;;
+            
+            end:
+        '''.parse.assertNoErrors
+    }
+    
+        @Test
+    def void testExample() {
+        '''
+                // You may run this MLM with: $ arden2bytecode -r example.mlm
+
+                maintenance:
+                    title: Example MLM;;
+                    mlmname: examplemlm;;
+                    arden: version 1.0;;
+                    version: 1.0;;
+                    institution: Peter L. Reichertz Institut;;
+                    author: Hannes Flicka;;
+                    specialist: Hannes Flicka;;
+                    date: 2012-04-04;;
+                    validation: testing;;
+                
+                library:
+                    purpose: Demonstration of the Arden Syntax Editor;;
+                    explanation: n.a.;;
+                    keywords: example, arden syntax editor, arden2bytecode;;
+                    links: http://arden2bytecode.sf.net/ ;;
+                
+                knowledge:
+                    type: data-driven;;
+                    data:
+                        // set the variables used in this program:
+                        let variable be 4; // <- here you can insert other values to try out
+                        // set a destination for the write statement later used:
+                        let dest be destination {stdout};;
+                    evoke: ;; // MLM is called directly
+                    logic:
+                        // double variable. could also use: variable := variable * 2;
+                        let variable be variable * 2;
+                        if variable > 6 then
+                            conclude true;  // execute action slot
+                        else
+                            conclude false; // do not run action slot
+                        endif;; 
+                    action:
+                        write "variable is: " || variable || "." at dest;;
+                end:
+        '''.parse.assertNoErrors
+    }
+	
+
+	
+}


### PR DESCRIPTION
The test project is required in order to generate xtext artifacts. It can also now be directly imported as an eclipse project after cloning the repository.

This fixes the following error when trying to generate the Xtext artifacts:

> java.io.FileNotFoundException: ../arden.xtext.tests/META-INF/MANIFEST.MF (No such file or directory)
