### PR TITLE
Fix 'INT' rule value converter error

### DIFF
--- a/arden.xtext/src/arden/xtext/ArdenSyntax.xtext
+++ b/arden.xtext/src/arden/xtext/ArdenSyntax.xtext
@@ -47,9 +47,9 @@ terminal fragment us: '_';
 //terminal data_mapping: 'data_mapping';
 
 // numbers
-terminal fragment INT: ('0'..'9')+;
-terminal exponent: ('e' | 'E') ('+' | '-')? INT;
-terminal number_literal : (INT ('.' INT?)? exponent?) | ('.' INT exponent?);
+terminal fragment ddigits: digit+;
+terminal exponent: ('e' | 'E') ('+' | '-')? ddigits;
+terminal number_literal : (ddigits ('.' ddigits?)? exponent?) | ('.' ddigits exponent?);
 
 // id & mlmname
 terminal ID : letter (letter | us | digit)*;
@@ -60,7 +60,7 @@ terminal fragment simplestring: !'"';
 terminal string_literal : '"' simplestring* ('""' simplestring+)* '"';
 
 // iso date/datetime
-terminal fragment fractional_seconds: ('.' INT)?;
+terminal fragment fractional_seconds: ('.' ddigits)?;
 terminal fragment time_zone: ('Z' | 'z' 
     | '+' digit digit ':' digit digit 
     | '-' digit digit ':' digit digit)?


### PR DESCRIPTION
As we don't use the org.eclipse.xtext.common.Terminals for our grammar,
we can use the rule 'INT', even as a fragment, but xtext always seems to
try to register a value converter to the 'INT' rule, which is not
possible for fragments.

This fixes the following error, which happens at plugin runtime:

> Tried to register a value converter for a fragment terminal rule: INT".
