### PR TITLE
Short outline

### DIFF
--- a/arden.xtext.ui/src/arden/xtext/ui/labeling/ArdenSyntaxLabelProvider.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/labeling/ArdenSyntaxLabelProvider.java
@@ -3,32 +3,83 @@
 */
 package arden.xtext.ui.labeling;
 
+import java.util.List;
+
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 
 import com.google.inject.Inject;
 
+import arden.xtext.ardenSyntax.P_mlm;
+import arden.xtext.ardenSyntax.action_slot;
+import arden.xtext.ardenSyntax.data_slot;
+import arden.xtext.ardenSyntax.evoke_slot;
+import arden.xtext.ardenSyntax.knowledge_category;
+import arden.xtext.ardenSyntax.library_category;
+import arden.xtext.ardenSyntax.logic_slot;
+import arden.xtext.ardenSyntax.maintenance_category;
+import arden.xtext.ardenSyntax.mlmname_text;
+
 /**
  * Provides labels for a EObjects.
  * 
- * see http://www.eclipse.org/Xtext/documentation/latest/xtext.html#labelProvider
+ * see
+ * http://www.eclipse.org/Xtext/documentation/latest/xtext.html#labelProvider
  */
 public class ArdenSyntaxLabelProvider extends DefaultEObjectLabelProvider {
 
-	@Inject
-	public ArdenSyntaxLabelProvider(AdapterFactoryLabelProvider delegate) {
-		super(delegate);
-	}
-
-/*
-	//Labels and icons can be computed like this:
-	
-	String text(MyModel ele) {
-	  return "my "+ele.getName();
-	}
-	 
-    String image(MyModel ele) {
-      return "MyModel.gif";
+    @Inject
+    public ArdenSyntaxLabelProvider(AdapterFactoryLabelProvider delegate) {
+        super(delegate);
     }
-*/
+
+    String text(P_mlm module) {
+        // check if mlmname element exists in module body
+        List<mlmname_text> nameTexts = EcoreUtil2.getAllContentsOfType(module, mlmname_text.class);
+        if (!nameTexts.isEmpty()) {
+            // return its id or text
+            mlmname_text nameText = nameTexts.get(0);
+
+            String name = nameText.getText();
+            if (name != null && !name.isEmpty()) {
+                return "MLM: " + name;
+            }
+        }
+        return "Medical Logic Module";
+    }
+
+    // TODO image for modules in outline
+    // String image(P_mlm module) {
+    // return "Module.gif";
+    // }
+
+    String text(maintenance_category libraryCategory) {
+        return "Maintenance";
+    }
+
+    String text(library_category libraryCategory) {
+        return "Library";
+    }
+
+    String text(knowledge_category knowledgeCategory) {
+        return "Knowledge";
+    }
+
+    String text(data_slot slot) {
+        return "data";
+    }
+
+    String text(evoke_slot slot) {
+        return "evoke";
+    }
+
+    String text(logic_slot slot) {
+        return "logic";
+    }
+
+    String text(action_slot slot) {
+        return "action";
+    }
+
 }

--- a/arden.xtext.ui/src/arden/xtext/ui/outline/ArdenSyntaxOutlineTreeProvider.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/outline/ArdenSyntaxOutlineTreeProvider.java
@@ -3,12 +3,72 @@
 */
 package arden.xtext.ui.outline;
 
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider;
+
+import arden.xtext.ardenSyntax.P_mlm;
+import arden.xtext.ardenSyntax.action_slot;
+import arden.xtext.ardenSyntax.data_slot;
+import arden.xtext.ardenSyntax.evoke_slot;
+import arden.xtext.ardenSyntax.knowledge_body;
+import arden.xtext.ardenSyntax.knowledge_category;
+import arden.xtext.ardenSyntax.library_category;
+import arden.xtext.ardenSyntax.logic_slot;
+import arden.xtext.ardenSyntax.maintenance_category;
+import arden.xtext.ardenSyntax.mlms;
 
 /**
  * customization of the default outline structure
  * 
  */
 public class ArdenSyntaxOutlineTreeProvider extends DefaultOutlineTreeProvider {
-	
+
+    protected void _createChildren(IOutlineNode parentNode, mlms mlms) {
+        // add child modules directly to file node
+        for (P_mlm node : mlms.getP_mlms()) {
+            createNode(parentNode, node);
+        }
+    }
+    
+    protected void _createChildren(IOutlineNode parentNode, knowledge_category knowledgeCategory) {
+        // skip body and append children directly to category
+        knowledge_body body = knowledgeCategory.getKnowledge_body();
+        if(body.getData_slot() != null)
+            createNode(parentNode, body.getData_slot());
+        if(body.getEvoke_slot() != null)
+            createNode(parentNode, body.getEvoke_slot());
+        if(body.getLogic_slot() != null)
+            createNode(parentNode, body.getLogic_slot());
+        if(body.getAction_slot() != null)
+            createNode(parentNode, body.getAction_slot());
+    }
+    
+    protected boolean _isLeaf(maintenance_category feature) {
+        return true;
+    }
+    
+    protected boolean _isLeaf(library_category feature) {
+        return true;
+    }
+    
+    protected boolean _isLeaf(data_slot dataSlot) {
+        // don't include statements to keep outline flat
+        return true;
+    }
+    
+    protected boolean _isLeaf(evoke_slot feature) {
+        // don't include statements to keep outline flat
+        return true;
+    }
+
+    protected boolean _isLeaf(logic_slot feature) {
+        // don't include statements to keep outline flat
+        return true;
+    }
+
+    protected boolean _isLeaf(action_slot feature) {
+        // don't include statements to keep outline flat
+        return true;
+    }
+
 }


### PR DESCRIPTION
This adds an outline which only shows modules, categories and data/evoke/logic/action slots, but not their content. This is especially useful when working with multiple modules in the same file.

Content (e.g. statements) is not shown, because it would basically mirror the code and lead to deep and confusing nesting on complex modules.
