### PR TITLE
Code folding

### DIFF
--- a/arden.xtext.ui/src/arden/xtext/ui/ArdenSyntaxUiModule.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/ArdenSyntaxUiModule.java
@@ -4,25 +4,32 @@
 package arden.xtext.ui;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 
-import arden.xtext.ui.syntaxcoloring.ArdenSyntaxSemanticHighlightingCalculator;
+import arden.xtext.ui.folding.ArdenSyntaxFoldingRegionProvider;
 import arden.xtext.ui.syntaxcoloring.ArdenSyntaxHighlightingConfiguration;
+import arden.xtext.ui.syntaxcoloring.ArdenSyntaxSemanticHighlightingCalculator;
 
 /**
  * Use this class to register components to be used within the IDE.
  */
 public class ArdenSyntaxUiModule extends arden.xtext.ui.AbstractArdenSyntaxUiModule {
-	public ArdenSyntaxUiModule(AbstractUIPlugin plugin) {
-		super(plugin);
-	}
-	
-	public Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
-		return ArdenSyntaxSemanticHighlightingCalculator.class;
-	}
-	
-	public Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
-		return ArdenSyntaxHighlightingConfiguration.class;
-	}
+    public ArdenSyntaxUiModule(AbstractUIPlugin plugin) {
+        super(plugin);
+    }
+
+    public Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
+        return ArdenSyntaxSemanticHighlightingCalculator.class;
+    }
+
+    public Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
+        return ArdenSyntaxHighlightingConfiguration.class;
+    }
+
+    public Class<? extends IFoldingRegionProvider> bindIFoldingRegionProvider() {
+        return ArdenSyntaxFoldingRegionProvider.class;
+    }
+
 }

--- a/arden.xtext.ui/src/arden/xtext/ui/folding/ArdenSyntaxFoldingRegionProvider.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/folding/ArdenSyntaxFoldingRegionProvider.java
@@ -1,0 +1,45 @@
+package arden.xtext.ui.folding;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ui.editor.folding.DefaultFoldingRegionProvider;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionAcceptor;
+import org.eclipse.xtext.util.ITextRegion;
+
+import arden.xtext.ardenSyntax.action_slot;
+import arden.xtext.ardenSyntax.data_slot;
+import arden.xtext.ardenSyntax.evoke_slot;
+import arden.xtext.ardenSyntax.knowledge_category;
+import arden.xtext.ardenSyntax.library_category;
+import arden.xtext.ardenSyntax.logic_slot;
+import arden.xtext.ardenSyntax.maintenance_category;
+
+public class ArdenSyntaxFoldingRegionProvider extends DefaultFoldingRegionProvider {
+
+    @Override
+    protected void computeObjectFolding(EObject eObject, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+        boolean fold = eObject instanceof maintenance_category
+                | eObject instanceof library_category
+                | eObject instanceof knowledge_category
+                | eObject instanceof data_slot
+                | eObject instanceof evoke_slot
+                | eObject instanceof logic_slot
+                | eObject instanceof action_slot;
+        
+        if(fold) {
+            computeObjectFolding(eObject, foldingRegionAcceptor, false);
+        }
+    }
+    
+    @Override
+    protected boolean shouldProcessContent(EObject object) {
+        boolean ignoreContent = object instanceof maintenance_category
+                | object instanceof library_category
+                | object instanceof data_slot
+                | object instanceof evoke_slot
+                | object instanceof logic_slot
+                | object instanceof action_slot;
+        
+        return !ignoreContent;
+    }
+    
+}


### PR DESCRIPTION
Only categories and slots which contain statements are foldable. In the default behavior multiline statements (while, if-else, ...) could be folded, which led to unnecessary many folding points.
