### PR TITLE
Syntaxhighlighting

### DIFF
--- a/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxHighlightingConfiguration.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxHighlightingConfiguration.java
@@ -7,20 +7,29 @@ import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfigurationAcce
 import org.eclipse.xtext.ui.editor.utils.TextStyle;
 
 public class ArdenSyntaxHighlightingConfiguration implements
-		IHighlightingConfiguration {
+        IHighlightingConfiguration {
 
-	public static final String DEFAULTHL = "defaultHighlighting";
+    public static final String KEYWORD_ID = "keyword";
+    public static final String COMMENT_ID = "comment";
 
-	public void configure(IHighlightingConfigurationAcceptor acceptor) {
-		acceptor.acceptDefaultHighlighting(DEFAULTHL, "Default Highlighting",
-				defaultHighlighting());
-	}
+    @Override
+    public void configure(IHighlightingConfigurationAcceptor acceptor) {
+        acceptor.acceptDefaultHighlighting(
+                COMMENT_ID, "Comment", commentTextStyle());
+        acceptor.acceptDefaultHighlighting(KEYWORD_ID, "Keyword",
+                keywordTextStyle());
+    }
 
-	public TextStyle defaultHighlighting() {
-		TextStyle textStyle = new TextStyle();
-		//textStyle.setBackgroundColor(new RGB(127, 255, 255));
-		textStyle.setColor(new RGB(127, 0, 85));
-		textStyle.setStyle(SWT.BOLD);
-		return textStyle;
-	}
+    public TextStyle keywordTextStyle() {
+        TextStyle textStyle = new TextStyle();
+        textStyle.setColor(new RGB(127, 0, 85));
+        textStyle.setStyle(SWT.BOLD);
+        return textStyle;
+    }
+    
+    public TextStyle commentTextStyle() {
+        TextStyle textStyle = new TextStyle();
+        textStyle.setColor(new RGB(63, 127, 95));
+        return textStyle;
+    }
 }

--- a/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxHighlightingConfiguration.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxHighlightingConfiguration.java
@@ -11,23 +11,30 @@ public class ArdenSyntaxHighlightingConfiguration implements
 
     public static final String KEYWORD_ID = "keyword";
     public static final String COMMENT_ID = "comment";
+    public static final String TEXT_ID = "text";
 
     @Override
     public void configure(IHighlightingConfigurationAcceptor acceptor) {
-        acceptor.acceptDefaultHighlighting(
-                COMMENT_ID, "Comment", commentTextStyle());
-        acceptor.acceptDefaultHighlighting(KEYWORD_ID, "Keyword",
-                keywordTextStyle());
+        acceptor.acceptDefaultHighlighting(COMMENT_ID, "Comment", commentTextStyle());
+        acceptor.acceptDefaultHighlighting(KEYWORD_ID, "Keyword", keywordTextStyle());
+        acceptor.acceptDefaultHighlighting(TEXT_ID, "Text", textTextStyle());
+        
     }
 
-    public TextStyle keywordTextStyle() {
+    private TextStyle textTextStyle() {
+        TextStyle textStyle = new TextStyle();
+        textStyle.setColor(new RGB(127, 127, 159));
+        return textStyle;
+    }
+
+    private TextStyle keywordTextStyle() {
         TextStyle textStyle = new TextStyle();
         textStyle.setColor(new RGB(127, 0, 85));
         textStyle.setStyle(SWT.BOLD);
         return textStyle;
     }
     
-    public TextStyle commentTextStyle() {
+    private TextStyle commentTextStyle() {
         TextStyle textStyle = new TextStyle();
         textStyle.setColor(new RGB(63, 127, 95));
         return textStyle;

--- a/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxSemanticHighlightingCalculator.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxSemanticHighlightingCalculator.java
@@ -68,7 +68,11 @@ public class ArdenSyntaxSemanticHighlightingCalculator implements ISemanticHighl
                     String name = t.getName();
                     int index = highlightNames.indexOf(name);
                     if (index != -1) {
+                        // special terminal rules
                         acceptor.addPosition(node.getOffset(), highlightLengths[index],
+                                ArdenSyntaxHighlightingConfiguration.KEYWORD_ID);
+                        // also highlight the ";;" part
+                        acceptor.addPosition(node.getTotalEndOffset()-2, 2,
                                 ArdenSyntaxHighlightingConfiguration.KEYWORD_ID);
                     }
                 }


### PR DESCRIPTION
This adds semantic syntax highlighting for:
- Comments - green default color
- Documentation slots (title, explanation, etc.)  - blueish default color, like javadoc comments
- Semicolons at the end of slots (was missing previously)
