### PR TITLE
Templates

### DIFF
--- a/arden.xtext.ui/build.properties
+++ b/arden.xtext.ui/build.properties
@@ -3,4 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               templates/

--- a/arden.xtext.ui/src/arden/xtext/ui/contentassist/ArdenSyntaxProposalProvider.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/contentassist/ArdenSyntaxProposalProvider.java
@@ -3,66 +3,45 @@
 */
 package arden.xtext.ui.contentassist;
 
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtext.RuleCall;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
+
 /**
  * see http://www.eclipse.org/Xtext/documentation/latest/xtext.html#contentAssist on how to customize content assistant
  */
 public class ArdenSyntaxProposalProvider extends AbstractArdenSyntaxProposalProvider {
-
+    
+    // no content assist for keywords which are already handled by templates
+    private static Set<String> FILTERED_KEYWORDS = new HashSet<String>(Arrays.asList(
+            "mlmname:",
+            "filename:",
+            "arden:",
+            "version:",
+            "date:",
+            "validation:",
+            "type:",
+            "priority:",
+            "urgency:",
+            "data:",
+            "evoke:",
+            "logic:",
+            "action:",
+            "maintenance:",
+            "library:",
+            "knowledge:"
+    ));
+    
     @Override
-	public void complete_TITLE_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_TITLE_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("title: ;;", context));
-	}
-
-    @Override
-	public void complete_INSTITUTION_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_INSTITUTION_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("institution: ;;", context));
-	}
-
-    @Override
-	public void complete_AUTHOR_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_AUTHOR_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("author: ;;", context));
-	}
-	
-    @Override
-	public void complete_SPECIALIST_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_SPECIALIST_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("specialist: ;;", context));
-	}
-	
-    @Override
-	public void complete_PURPOSE_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_PURPOSE_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("purpose: ;;", context));
-	}
-	
-    @Override
-	public void complete_EXPLANATION_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_EXPLANATION_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("explanation: ;;", context));
-	}
-	
-    @Override
-	public void complete_KEYWORDS_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_KEYWORDS_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("keywords: ;;", context));
-	}
-	
-    @Override
-	public void complete_CITATIONS_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_CITATIONS_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("citations: ;;", context));
-	}
-	
-    @Override
-	public void complete_LINKS_SLOT(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		super.complete_LINKS_SLOT(model, ruleCall, context, acceptor);
-		acceptor.accept(createCompletionProposal("links: ;;", context));
-	}
+    public void completeKeyword(Keyword keyword, ContentAssistContext contentAssistContext, ICompletionProposalAcceptor acceptor) {
+        if (FILTERED_KEYWORDS.contains(keyword.getValue())) {
+            // don't propose keyword
+            return;
+        }
+        super.completeKeyword(keyword, contentAssistContext, acceptor);
+    }
 }

--- a/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxSemanticHighlightingCalculator.java
+++ b/arden.xtext.ui/src/arden/xtext/ui/syntaxcoloring/ArdenSyntaxSemanticHighlightingCalculator.java
@@ -19,15 +19,15 @@ import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculato
 public class ArdenSyntaxSemanticHighlightingCalculator implements ISemanticHighlightingCalculator {
     
     private static List<String> slotTerminals = Arrays.asList(
-            "TITLE_SLOT",
-            "INSTITUTION_SLOT", 
-            "AUTHOR_SLOT",
-            "SPECIALIST_SLOT",
-            "PURPOSE_SLOT",
-            "EXPLANATION_SLOT",
-            "KEYWORDS_SLOT",
-            "CITATIONS_SLOT",
-            "LINKS_SLOT"
+            "TITLE_SLOT_TERMINAL",
+            "INSTITUTION_SLOT_TERMINAL", 
+            "AUTHOR_SLOT_TERMINAL",
+            "SPECIALIST_SLOT_TERMINAL",
+            "PURPOSE_SLOT_TERMINAL",
+            "EXPLANATION_SLOT_TERMINAL",
+            "KEYWORDS_SLOT_TERMINAL",
+            "CITATIONS_SLOT_TERMINAL",
+            "LINKS_SLOT_TERMINAL"
     );
     
     private static int[] slotTerminalLabelLengths = new int[] {

--- a/arden.xtext.ui/templates/templates.xml
+++ b/arden.xtext.ui/templates/templates.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE templates>
+<templates>
+<template id="New Module" autoinsert="true" context="arden.xtext.ArdenSyntax.kw_maintenance:" deleted="false" description="Create a blank MLM" enabled="true" name="New Module">maintenance: 
+	title: ${My_Module} ;;
+	mlmname: ${myMLM};;
+	arden: version 2.5;;
+	version: 1.0;;
+	institution: ;;
+	author: ;;
+	specialist: ;;
+	date: 2012-09-05;;
+	validation: testing;;
+
+library: 
+	purpose: ;;
+	explanation: ;;
+	keywords: ;;
+	citations: ;;
+	links: ;;
+
+knowledge:
+	type: data-driven;;
+
+data:
+;;
+
+evoke: 
+;;
+
+logic: 
+;;
+
+action:
+;;
+
+end:
+</template>
+</templates>

--- a/arden.xtext.ui/templates/templates.xml
+++ b/arden.xtext.ui/templates/templates.xml
@@ -1,39 +1,150 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE templates>
 <templates>
-<template id="New Module" autoinsert="true" context="arden.xtext.ArdenSyntax.kw_maintenance:" deleted="false" description="Create a blank MLM" enabled="true" name="New Module">maintenance: 
-	title: ${My_Module} ;;
-	mlmname: ${myMLM};;
-	arden: version 2.5;;
-	version: 1.0;;
-	institution: ;;
-	author: ;;
-	specialist: ;;
-	date: 2012-09-05;;
-	validation: testing;;
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.kw_maintenance:" deleted="false" description="Create a blank MLM" enabled="true" id="New Module" name="New Module">maintenance: 
+    title: ${My_Module} ;;
+    mlmname: ${myMLM};;
+    arden: version 2.5;;
+    version: 1.0;;
+    institution: ${institution};;
+    author: ${user};;
+    specialist: ;;
+    date: 2012-09-05;;
+    validation: testing;;
 
 library: 
-	purpose: ;;
-	explanation: ;;
-	keywords: ;;
-	citations: ;;
-	links: ;;
+    purpose: ${purpose};;
+    explanation: ${explanation};;
+    keywords: ${keywords};;
+    citations: ${citations};;
+    links: ${links};;
 
 knowledge:
-	type: data-driven;;
+    type: data-driven;;
 
-data:
-;;
+    data:
+    ;;
 
-evoke: 
-;;
+    evoke: 
+    ;;
 
-logic: 
-;;
+    logic: 
+    ;;
 
-action:
-;;
+    action:
+    ;;
 
 end:
 </template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.kw_maintenance:" deleted="false" description="Add the maintenance category" enabled="true" id="Maintenance category" name="Maintenance category">maintenance: 
+    title: ${My_Module} ;;
+    mlmname: ${myMLM};;
+    arden: version 2.5;;
+    version: 1.0;;
+    institution: ${institution};;
+    author: ${user};;
+    specialist: ;;
+    date: 2012-09-05;;
+    validation: testing;;
+
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.kw_library:" deleted="false" description="Add the library category" enabled="true" id="Library category" name="Library category">library: 
+    purpose: ${purpose};;
+    explanation: ${explanation};;
+    keywords: ${keywords};;
+    citations: ${citations};;
+    links: ${links};;
+
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.kw_knowledge:" deleted="false" description="Add the knowledge category" enabled="true" id="Knowledge category" name="Knowledge category">knowledge:
+    type: data-driven;;
+
+    data:
+    ;;
+
+    evoke: 
+    ;;
+
+    logic: 
+    ;;
+
+    action:
+    ;;
+
+end:
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.title_slot" deleted="false" description="title slot" enabled="true" id="title" name="title">title: ${My_Module} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.mlmname_slot" deleted="false" description="mlmname slot" enabled="true" id="mlmname" name="mlmname">mlmname: ${myMLM};;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.mlmname_slot" deleted="false" description="filename slot" enabled="true" id="filename" name="filename">filename: ${filename};;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.arden_version_slot" deleted="false" description="arden version slot" enabled="true" id="arden version" name="arden version">arden: version ${version} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.version_slot" deleted="false" description="version slot" enabled="true" id="version" name="version">version: ${version} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.institution_slot" deleted="false" description="institution slot" enabled="true" id="institution" name="institution">institution: ${institution} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.author_slot" deleted="false" description="author slot" enabled="true" id="author" name="author">author: ${user} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.specialist_slot" deleted="false" description="specialist slot" enabled="true" id="specialist" name="specialist">specialist: ${specialist} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.date_slot" deleted="false" description="date slot" enabled="true" id="date" name="date">date: ${2015_6_23} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.validation_slot" deleted="false" description="validation slot" enabled="true" id="validation" name="validation">validation: ${testing} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.purpose_slot" deleted="false" description="purpose slot" enabled="true" id="purpose" name="purpose">purpose: ${purpose} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.explanation_slot" deleted="false" description="explanation slot" enabled="true" id="explanation" name="explanation">explanation: ${explanation} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.keywords_slot" deleted="false" description="keywords slot" enabled="true" id="keywords" name="keywords">keywords: ${keywords} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.citations_slot" deleted="false" description="citations slot" enabled="true" id="citations" name="citations">citations: ${citations} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.links_slot" deleted="false" description="links slot" enabled="true" id="links" name="links">links: ${links} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.type_slot" deleted="false" description="type slot" enabled="true" id="type" name="type">type: ${data_driven} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.data_slot" deleted="false" description="data slot" enabled="true" id="data" name="data">data: ${cursor}
+;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.evoke_slot" deleted="false" description="evoke slot" enabled="true" id="evoke" name="evoke">evoke: ${cursor}
+;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.logic_slot" deleted="false" description="logic slot" enabled="true" id="logic" name="logic">logic: ${cursor}
+;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.action_slot" deleted="false" description="action slot" enabled="true" id="action" name="action">action: ${cursor}
+;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.priority_slot" deleted="false" description="priority slot" enabled="true" id="priority" name="priority">priority: ${priority} ;;
+</template>
+
+<template autoinsert="true" context="arden.xtext.ArdenSyntax.urgency_slot" deleted="false" description="urgency slot" enabled="true" id="urgency" name="urgency">urgency: ${urgency} ;;
+</template>
+
 </templates>

--- a/arden.xtext/src/arden/xtext/ArdenSyntax.xtext
+++ b/arden.xtext/src/arden/xtext/ArdenSyntax.xtext
@@ -90,13 +90,13 @@ maintenance_category:
                 'maintenance:' maintainance_body=maintenance_body;
 
 maintenance_body :
-                title_slot=TITLE_SLOT
+                title_slot=title_slot
                 mlmname_slot=mlmname_slot
-                arden_version_slot=arden_version_slot
+                arden_version_slot=arden_version_slot?
                 version_slot=version_slot
-                institution_slot=INSTITUTION_SLOT
-                author_slot=AUTHOR_SLOT
-                specialist_slot=SPECIALIST_SLOT
+                institution_slot=institution_slot
+                author_slot=author_slot
+                specialist_slot=specialist_slot
                 date_slot=date_slot
                 validation_slot=validation_slot;
 
@@ -104,11 +104,11 @@ library_category :
                 'library:' library_body=library_body;
 
 library_body :
-                purpose_slot=PURPOSE_SLOT
-                explanation_slot=EXPLANATION_SLOT
-                keywords_slot=KEYWORDS_SLOT
-                citations_slot=CITATIONS_SLOT?
-                links_slot=LINKS_SLOT?;
+                purpose_slot=purpose_slot
+                explanation_slot=explanation_slot
+                keywords_slot=keywords_slot
+                citations_slot=citations_slot?
+                links_slot=links_slot?;
 
 knowledge_category :
                 'knowledge:' knowledge_body=knowledge_body;
@@ -116,17 +116,17 @@ knowledge_category :
 knowledge_body :
                 type_slot=type_slot
                 data_slot=data_slot
-                priority_slot=priority_slot
+                priority_slot=priority_slot?
                 evoke_slot=evoke_slot
                 logic_slot=logic_slot
                 action_slot=action_slot
-                urgency_slot=urgency_slot;
+                urgency_slot=urgency_slot?;
                 
 
 /****** slots ******/
 /****** maintenance: slots ******/
-
-terminal TITLE_SLOT :
+title_slot: value=TITLE_SLOT_TERMINAL;
+terminal TITLE_SLOT_TERMINAL :
                 'title:' -> ';;';
 
 mlmname_slot :
@@ -135,23 +135,23 @@ mlmname_slot :
 
 
 arden_version_slot :
-	{arden_version_slot}
-      ('arden:' 'version' 
+      'arden:' 'version' 
       	version_number=NUMBER_LITERAL 
-      	';;'
-      )?;  
+      	';;';  
     
 version_slot :
                 'version:' vnum=NUMBER_LITERAL ';;';
 
-terminal INSTITUTION_SLOT :
+institution_slot: value=INSTITUTION_SLOT_TERMINAL;
+terminal INSTITUTION_SLOT_TERMINAL :
                 'institution:' -> ';;';
 
-terminal AUTHOR_SLOT :
+author_slot: value=AUTHOR_SLOT_TERMINAL;
+terminal AUTHOR_SLOT_TERMINAL :
                 'author:' -> ';;';
 
-
-terminal SPECIALIST_SLOT :
+specialist_slot: value=SPECIALIST_SLOT_TERMINAL;
+terminal SPECIALIST_SLOT_TERMINAL :
                 'specialist:' -> ';;';
 
 
@@ -175,17 +175,26 @@ validation_code :
 
 /****** library: slots ******/
 
-terminal PURPOSE_SLOT: 'purpose:' -> ';;';
-terminal EXPLANATION_SLOT: 'explanation:' -> ';;';
-terminal KEYWORDS_SLOT: 'keywords:' -> ';;';
-terminal CITATIONS_SLOT: 'citations:' -> ';;';
-terminal LINKS_SLOT: 'links:' -> ';;';
+purpose_slot: value=PURPOSE_SLOT_TERMINAL;
+terminal PURPOSE_SLOT_TERMINAL: 'purpose:' -> ';;';
+
+explanation_slot: value=EXPLANATION_SLOT_TERMINAL;
+terminal EXPLANATION_SLOT_TERMINAL: 'explanation:' -> ';;';
+
+keywords_slot: value=KEYWORDS_SLOT_TERMINAL;
+terminal KEYWORDS_SLOT_TERMINAL: 'keywords:' -> ';;';
+
+citations_slot: value=CITATIONS_SLOT_TERMINAL;
+terminal CITATIONS_SLOT_TERMINAL: 'citations:' -> ';;';
+
+links_slot: value=LINKS_SLOT_TERMINAL;
+terminal LINKS_SLOT_TERMINAL: 'links:' -> ';;';
 
 
 /****** knowledge: slots ******/
 
 type_slot :
-                'type:'
+                'type:' type=
                 	('data_driven'
     				| 'data-driven') 
                 ';;';
@@ -198,8 +207,7 @@ data_slot :
                 'data:' data_block=data_block ';;';
 
 priority_slot :
-      {priority_slot}
-    ('priority:' priority=NUMBER_LITERAL ';;')?;
+                'priority:' priority=NUMBER_LITERAL ';;';
 
 evoke_slot :
                 'evoke:' evoke_block=evoke_block ';;';
@@ -211,8 +219,7 @@ action_slot :
                 'action:' action_block=action_block ';;';
 
 urgency_slot :
-      {urgency_slot}
-    ('urgency:' urgency=urgency_val ';;')?;
+                'urgency:' urgency=urgency_val ';;';
 
 urgency_val :
       NUMBER_LITERAL


### PR DESCRIPTION
This adds templates to quickly generate:
- New Modules
- All Categories
- All slots

Templates are more powerful and user-friendly, compared to the syntax proposal API. For example they may contain placeholder fields (switch between them with the tab key), and change the cursor position (`${cursor}`).
When only 1 proposal/template is available after using content assist (ctrl + space) it is inserted directly, therefore syntax proposals for keywords/terminals for which a template already exists, is disabled.

Terminals can't be used as a templates context, therefore all maintenance/library/knowledge slots are now appended to the AST with parserules instead of terminalrules.
