### PR TITLE
Better error message on new empty files

### DIFF
--- a/arden.xtext/src/arden/xtext/ArdenSyntaxRuntimeModule.java
+++ b/arden.xtext/src/arden/xtext/ArdenSyntaxRuntimeModule.java
@@ -3,9 +3,15 @@
  */
 package arden.xtext;
 
+import org.eclipse.xtext.parser.antlr.ISyntaxErrorMessageProvider;
+
+import arden.xtext.validation.ArdenSyntaxSyntaxErrorMessageProvider;
+
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
 public class ArdenSyntaxRuntimeModule extends arden.xtext.AbstractArdenSyntaxRuntimeModule {
-
+    public Class<? extends ISyntaxErrorMessageProvider> bindISyntaxErrorMessageProvider() {
+        return ArdenSyntaxSyntaxErrorMessageProvider.class;
+    }
 }

--- a/arden.xtext/src/arden/xtext/validation/ArdenSyntaxSyntaxErrorMessageProvider.java
+++ b/arden.xtext/src/arden/xtext/validation/ArdenSyntaxSyntaxErrorMessageProvider.java
@@ -1,0 +1,20 @@
+package arden.xtext.validation;
+
+import org.antlr.runtime.EarlyExitException;
+import org.antlr.runtime.RecognitionException;
+import org.eclipse.xtext.nodemodel.SyntaxErrorMessage;
+import org.eclipse.xtext.parser.antlr.SyntaxErrorMessageProvider;
+
+public class ArdenSyntaxSyntaxErrorMessageProvider extends SyntaxErrorMessageProvider {
+    public static final String MISSING_MODULE = "MISSING_MODULE";
+    
+    @Override
+    public SyntaxErrorMessage getSyntaxErrorMessage(IParserErrorContext context) {
+        RecognitionException exception = context.getRecognitionException();
+        if (exception != null && exception.line == 0 && exception instanceof EarlyExitException) {
+            return new SyntaxErrorMessage("At least one Module is required", MISSING_MODULE);
+        }
+            
+        return super.getSyntaxErrorMessage(context);
+    }
+}


### PR DESCRIPTION
A new .mlm file always shows the following cryptic error:

> required (...)+ loop did not match anything at input '<EOF>'

Now it shows a much clearer error message:

> At least one Module is required
