### PR TITLE
Support for Eclipse versions previous to Mars

### DIFF
--- a/arden.plugin.editor.ui/META-INF/MANIFEST.MF
+++ b/arden.plugin.editor.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: arden.plugin.editor.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: arden.plugin.editor,
- org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui;bundle-version="2.9.0",
  org.eclipse.xtext.ui.shared,
  org.eclipse.xtext.ui.codetemplates.ui,
  org.eclipse.ui.editors;bundle-version="3.5.0",

--- a/arden.plugin.editor/META-INF/MANIFEST.MF
+++ b/arden.plugin.editor/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Arden2ByteCode Team
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: arden.plugin.editor; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
+Require-Bundle: org.eclipse.xtext;bundle-version="2.9.0",
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.emf.common,

--- a/arden.plugin.update-site/associateSites.xml
+++ b/arden.plugin.update-site/associateSites.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE associateSites>
+<!-- Adds an update-site for the newest Xtext Version -->
+<associateSites>
+  <associateSite url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/" label="Xtext" />
+</associateSites>

--- a/arden.plugin.update-site/site.xml
+++ b/arden.plugin.update-site/site.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE site>
 <site>
+   <description name="Arden4Eclipse" url="https://plri.github.io/ardensyntax-eclipse-plugin/update/">
+      The Arden4Eclipse update site contains the Arden Syntax Editor and the Arden2ByteCode Integration.
+   </description>
    <feature url="features/arden.plugin.compiler.feature_1.0.0.qualifier.jar" id="arden.plugin.compiler.feature" version="1.0.0.qualifier">
       <category name="arden.plugin.category"/>
    </feature>

--- a/arden.plugin.update-site/site.xml
+++ b/arden.plugin.update-site/site.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<site>
+<!DOCTYPE site>
+<site associateSitesURL="associateSites.xml">
    <description name="Arden4Eclipse" url="https://plri.github.io/ardensyntax-eclipse-plugin/update/">
       The Arden4Eclipse update site contains the Arden Syntax Editor and the Arden2ByteCode Integration.
    </description>


### PR DESCRIPTION
Eclipse versions previous to Mars (Luna, Kepler, ...) don't support Xtext >= v2.9 out of the box.
This adds the [Xtext update-site](http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/) as an _associateSite_ to the update-site project so the newest Xtext version can be downloaded.

Other ways I tried, which **don't** work: 
- Adding a _Site to Visit_ in [feature.xml](/PLRI/ardensyntax-eclipse-plugin/blob/master/arden.plugin.editor.feature/feature.xml) via the _Feature Manifest Editor_ &rArr; _Information_ &rArr; _Sites to Visit_ (update-site is added, but disabled :expressionless:)
- Adding the following to [p2.inf](/PLRI/ardensyntax-eclipse-plugin/blob/master/arden.plugin.editor.feature/p2.inf) (features seem to be found at first, but error during installation):

```
instructions.configure=\
org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,location:http${#58}//download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,name:Xtext,enabled:true);\
org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,location:http${#58}//download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,name:Xtext,enabled:true);
```
