### PR TITLE
Update Templates

### DIFF
--- a/arden.plugin.editor.feature/feature.xml
+++ b/arden.plugin.editor.feature/feature.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE feature>
 <feature
       id="arden.plugin.editor.feature"
       label="Arden Syntax Editor"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="Arden2ByteCode Team">
 
    <description url="https://plri.github.io/arden2bytecode/arden4eclipse/">

--- a/arden.plugin.editor.ui/META-INF/MANIFEST.MF
+++ b/arden.plugin.editor.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: arden.plugin.editor,
  org.eclipse.xtext.builder,
  org.eclipse.xtext.common.types.ui,
  org.eclipse.core.runtime,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.eclipse.text
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: arden.plugin.editor.ui.contentassist,

--- a/arden.plugin.editor.ui/src/arden/plugin/editor/ui/ArdenSyntaxUiModule.java
+++ b/arden.plugin.editor.ui/src/arden/plugin/editor/ui/ArdenSyntaxUiModule.java
@@ -9,6 +9,7 @@ import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
 import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
+import org.eclipse.xtext.ui.editor.templates.DefaultTemplateProposalProvider;
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContextType;
 import org.eclipse.xtext.ui.wizard.IProjectCreator;
 
@@ -20,6 +21,7 @@ import arden.plugin.editor.ui.syntaxcoloring.ArdenSyntaxAntlrTokenToAttributeIdM
 import arden.plugin.editor.ui.syntaxcoloring.ArdenSyntaxHighlightingConfiguration;
 import arden.plugin.editor.ui.syntaxcoloring.ArdenSyntaxSemanticHighlightingCalculator;
 import arden.plugin.editor.ui.templates.ArdenSyntaxTemplateContextType;
+import arden.plugin.editor.ui.templates.ArdenSyntaxTemplateProposalProvider;
 import arden.plugin.editor.ui.wizard.ArdenSyntaxProjectCreator;
 
 /**
@@ -59,5 +61,9 @@ public class ArdenSyntaxUiModule extends AbstractArdenSyntaxUiModule {
 	
     public Class<? extends AbstractEditStrategyProvider> bindAbstractEditStrategyProvider() {
     	return ArdenSyntaxAutoEditStrategyProvider.class ;
-    }    
+    }
+    
+	public Class<? extends DefaultTemplateProposalProvider> bindDefaultTemplateProposalProvider() {
+		return ArdenSyntaxTemplateProposalProvider.class;
+	}
 }

--- a/arden.plugin.editor.ui/src/arden/plugin/editor/ui/templates/ArdenSyntaxTemplateProposalProvider.java
+++ b/arden.plugin.editor.ui/src/arden/plugin/editor/ui/templates/ArdenSyntaxTemplateProposalProvider.java
@@ -1,0 +1,27 @@
+package arden.plugin.editor.ui.templates;
+
+import org.eclipse.jface.text.templates.ContextTypeRegistry;
+import org.eclipse.jface.text.templates.Template;
+import org.eclipse.jface.text.templates.persistence.TemplateStore;
+import org.eclipse.xtext.ui.editor.templates.ContextTypeIdHelper;
+import org.eclipse.xtext.ui.editor.templates.DefaultTemplateProposalProvider;
+
+import com.google.inject.Inject;
+
+public class ArdenSyntaxTemplateProposalProvider extends DefaultTemplateProposalProvider {
+	
+	public static final int RELEVANCE = 10000;
+
+	@Inject
+	public ArdenSyntaxTemplateProposalProvider(TemplateStore templateStore, ContextTypeRegistry registry,
+			ContextTypeIdHelper helper) {
+		super(templateStore, registry, helper);
+	}
+	
+	@Override
+	public int getRelevance(Template template){
+		// show templates before keywords in content assist popup
+		return RELEVANCE;
+	}
+
+}

--- a/arden.plugin.editor.ui/templates/templates.xml
+++ b/arden.plugin.editor.ui/templates/templates.xml
@@ -143,18 +143,30 @@ end:
 <template autoinsert="true" context="arden.plugin.editor.ArdenSyntax.urgency_slot" deleted="false" description="urgency slot" enabled="true" id="urgency" name="urgency">urgency: ${urgency} ;;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_while" deleted="false" description="Add while loop" enabled="true" id="while" name="while">WHILE ${condition} DO
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_while" deleted="false" description="while loop" enabled="true" id="while" name="while">WHILE ${condition} DO
     ${cursor};
 ENDDO;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_for" deleted="false" description="Add for loop" enabled="true" id="for" name="for">FOR ${item} IN ${collection} DO
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_for" deleted="false" description="iterate over collection" enabled="true" id="foreach" name="foreach">FOR ${item} IN ${collection} DO
     ${cursor};
 ENDDO;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_if" deleted="false" description="Add if statement" enabled="true" id="if" name="if">IF ${condition} THEN
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_for" deleted="false" description="iterate over sequence" enabled="true" id="for" name="for">FOR ${i} IN ${1} SEQTO ${10} DO
     ${cursor};
+ENDDO;
+</template>
+
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_if" deleted="false" description="if statement" enabled="true" id="if" name="if">IF ${condition} THEN
+    ${cursor};
+ENDIF;
+</template>
+
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_if" deleted="false" description="if else statement" enabled="true" id="ifelse" name="ifelse">IF ${condition} THEN
+    ${cursor};
+ELSE
+    ;
 ENDIF;
 </template>
 

--- a/arden.plugin.editor.ui/templates/templates.xml
+++ b/arden.plugin.editor.ui/templates/templates.xml
@@ -20,7 +20,7 @@ library:
     links: ${links};;
 
 knowledge:
-    type: data-driven;;
+    type: data_driven;;
 
     data: ;;
 
@@ -58,7 +58,7 @@ end:
 </template>
 
 <template autoinsert="true" context="arden.plugin.editor.ArdenSyntax.kw_knowledge:" deleted="false" description="Add the knowledge category" enabled="true" id="Knowledge category" name="Knowledge category">knowledge:
-    type: data-driven;;
+    type: data_driven;;
 
     data: ;;
 

--- a/arden.plugin.editor.ui/templates/templates.xml
+++ b/arden.plugin.editor.ui/templates/templates.xml
@@ -143,19 +143,19 @@ end:
 <template autoinsert="true" context="arden.plugin.editor.ArdenSyntax.urgency_slot" deleted="false" description="urgency slot" enabled="true" id="urgency" name="urgency">urgency: ${urgency} ;;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_while" deleted="false" description="Add while loop" enabled="true" id="while" name="while">while ${condition} do
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_while" deleted="false" description="Add while loop" enabled="true" id="while" name="while">WHILE ${condition} DO
     ${cursor};
-enddo;
+ENDDO;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_for" deleted="false" description="Add for loop" enabled="true" id="for" name="for">for ${loop_variable} in ${collection} do
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_for" deleted="false" description="Add for loop" enabled="true" id="for" name="for">FOR ${item} IN ${collection} DO
     ${cursor};
-enddo;
+ENDDO;
 </template>
 
-<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_if" deleted="false" description="Add if statement" enabled="true" id="if" name="if">if ${condition} then
+<template autoinsert="false" context="arden.plugin.editor.ArdenSyntax.kw_if" deleted="false" description="Add if statement" enabled="true" id="if" name="if">IF ${condition} THEN
     ${cursor};
-endif;
+ENDIF;
 </template>
 
 </templates>

--- a/arden.plugin.update-site/site.xml
+++ b/arden.plugin.update-site/site.xml
@@ -7,7 +7,7 @@
    <feature url="features/arden.plugin.compiler.feature_1.1.0.qualifier.jar" id="arden.plugin.compiler.feature" version="1.1.0.qualifier">
       <category name="arden.plugin.category"/>
    </feature>
-   <feature url="features/arden.plugin.editor.feature_1.2.0.qualifier.jar" id="arden.plugin.editor.feature" version="1.2.0.qualifier">
+   <feature url="features/arden.plugin.editor.feature_1.2.1.qualifier.jar" id="arden.plugin.editor.feature" version="1.2.1.qualifier">
       <category name="arden.plugin.category"/>
    </feature>
    <category-def name="arden.plugin.category" label="Arden4Eclipse">


### PR DESCRIPTION
Changes:
- Templates are now shown before keyword content assist proposals
- Use "data_driven" instead of deprecated type "data-driven" in templates
- Keywords in templates are now uppercase
- More templates:
  - If-else statement
  - Sequence loop
