### PR TITLE
Fix plugin updates not working

### DIFF
--- a/arden.plugin.compiler.feature/feature.xml
+++ b/arden.plugin.compiler.feature/feature.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE feature>
 <feature
       id="arden.plugin.compiler.feature"
       label="Arden2ByteCode Integration"

--- a/arden.plugin.editor.feature/feature.xml
+++ b/arden.plugin.editor.feature/feature.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE feature>
 <feature
       id="arden.plugin.editor.feature"
       label="Arden Syntax Editor"

--- a/arden.plugin.editor.feature/p2.inf
+++ b/arden.plugin.editor.feature/p2.inf
@@ -1,2 +1,4 @@
 update.id = ArdenSyntaxEditor.feature.group
-update.range = [1.0.0.$qualifier$, 1.1.0.$qualifier$)
+update.matchExp = providedCapabilities.exists(pc | pc.namespace == 'org.eclipse.equinox.p2.iu' && ( \
+ pc.name == 'arden.plugin.editor.feature.feature.group' || \
+ pc.name == 'ArdenSyntaxEditor.feature.group'))


### PR DESCRIPTION
In the structure update (#14) the editor feature got a new id (_arden.plugin.editor.feature.feature.group_). Editor features with the old id (_ArdenSyntaxEditor.feature.group_) could still be updated by specifying the id in the `p2.inf` file. This however prevents features with the new id to be updated  ( e.g. via _help_ &rArr; _check for updates_).
This support updating editor plugins with both old and new feature ids, by specifying both ids in the `p2.inf` file.
